### PR TITLE
Game art box size fitting.

### DIFF
--- a/320x240/BigCody/theme.ini
+++ b/320x240/BigCody/theme.ini
@@ -32,9 +32,9 @@ items_separation = 17
 
 ;Game art
 art_x = 104
-art_y = 27
+art_y = 28
 art_max_w = 216
-art_max_h = 161
+art_max_h = 159
 art_text_distance_from_picture = 5
 art_text_line_separation = 14
 art_text_font_size = 12


### PR DESCRIPTION
In low res version the game previews overlaped the border.